### PR TITLE
No json.hpp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ $(MILHOJA_H): $(MAKEFILES) | $(BUILDDIR)
 # - Program depends directly on Milhoja.h and other Milhoja headers
 # - Sizes might change if compiler flags are changed
 $(SIZES_JSON): $(TOOLSDIR)/createSizesJson.cpp $(MILHOJA_H) $(CPP_HDRS) $(MAKEFILES)
-	$(CXXCOMP) $(TOOLSDIR)/createSizesJson.cpp $(DEPFLAGS) $(CXXFLAGS) -I$(JSONDIR) -o $(BUILDDIR)/createSizesJson.x
+	$(CXXCOMP) $(TOOLSDIR)/createSizesJson.cpp $(DEPFLAGS) $(CXXFLAGS) -o $(BUILDDIR)/createSizesJson.x
 	$(BUILDDIR)/createSizesJson.x $(SIZES_JSON)
 
 $(BUILDDIR)/%.o: $(SRCDIR)/%.cpp $(MILHOJA_H) $(HDRS) $(MAKEFILES)

--- a/Makefile.base
+++ b/Makefile.base
@@ -46,12 +46,12 @@ CUFLAGS_LIB  =
 # Combine all compiler and linker flags
 # TODO: Can we get rid of the AMReX flags when compiling?
 ifeq ($(DEBUG),true)
-CXXFLAGS = -I$(BUILDDIR) -I$(JSONDIR) -I$(LIB_MILHOJA)/include \
+CXXFLAGS = -I$(BUILDDIR) -I$(LIB_MILHOJA)/include \
 			$(CXXFLAGS_STD) $(CXXFLAGS_DEBUG) $(CXXFLAGS_BASE) \
 			$(CXXFLAGS_LIB) $(CXXFLAGS_TEST_DEBUG) \
             $(CXXFLAGS_GENERATED_DEBUG) $(CXXFLAGS_AMREX)
 else
-CXXFLAGS = -I$(BUILDDIR) -I$(JSONDIR) -I$(LIB_MILHOJA)/include \
+CXXFLAGS = -I$(BUILDDIR) -I$(LIB_MILHOJA)/include \
 			$(CXXFLAGS_STD) $(CXXFLAGS_PROD) $(CXXFLAGS_BASE) \
            $(CXXFLAGS_LIB) $(CXXFLAGS_TEST_PROD) \
            $(CXXFLAGS_GENERATED_PROD) $(CXXFLAGS_AMREX)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Requirements
 * Fortran compiler that supports F2003
 * MPI installation associated with the aforementioned C++ and Fortran compilers
 * googletest built with same compilers that will be used to build tests
-* Source-only installation of [nlohmann's C++ JSON library](https://github.com/nlohmann/json)
 * AMReX [123]D libraries including Fortran interfaces built with same compilers/MPI implementation that will be used to build tests
 
 Building Milhoja as a library

--- a/includes/Milhoja_ThreadTeamState.h
+++ b/includes/Milhoja_ThreadTeamState.h
@@ -5,10 +5,6 @@
  * derived classes that will implement the ThreadTeam state-specific behavior.
  * This design follows the State design pattern.
  *
- * The template variable DT defines the data type (e.g. a tile, data packet of
- * tiles); T, refers to the main State class in the State design pattern and
- * should therefore always be ThreadTeam<DT>.  Note that T is necessary to break
- * a circular dependence with ThreadTeam.h.
  */
 
 #ifndef MILHOJA_THREAD_TEAM_STATE_H__

--- a/sites/gce/Makefile.site.gnu_mpich
+++ b/sites/gce/Makefile.site.gnu_mpich
@@ -21,7 +21,6 @@ else
   AMREXDIR     = $(MILHOJA_TEST_CLONE)/gce/gnu_current/AMReX_$(NDIM)D
 endif
 GTESTDIR     = $(MILHOJA_TEST_CLONE)/gce/gnu_current/googletest
-JSONDIR      = $(MILHOJA_TEST_CLONE)/gce/gnu_current/json/single_include
 CUDADIR      =
 
 CXXCOMPNAME  = gnu

--- a/sites/gce/Makefile.site.intel_mpich
+++ b/sites/gce/Makefile.site.intel_mpich
@@ -3,7 +3,6 @@
 BASEDIR      = $(MILHOJA_CODE_REPO)
 AMREXDIR     = $(MILHOJA_TEST_CLONE)/gce/intel_current/AMReX_$(NDIM)D
 GTESTDIR     = $(MILHOJA_TEST_CLONE)/gce/intel_current/googletest
-JSONDIR      = $(MILHOJA_TEST_CLONE)/gce/intel_current/json/single_include
 CUDADIR      =
 
 CXXCOMPNAME  = intel

--- a/sites/gce/kw_build_inst.sh
+++ b/sites/gce/kw_build_inst.sh
@@ -2,7 +2,7 @@
 #
 # Modify manually in 2 places below to build for 1D or 3D instead of 2D.
 
-export MILHOJA_CODE_REPO=/home/kweide/refact/OrchestrationRuntime
+export MILHOJA_CODE_REPO=/home/kweide/projects/Milhoja
 export KW_INSTALL_DIR=/nfs/gce/projects/FLASH5/kweide/local-milhoja/2d
 
 set -xve
@@ -14,7 +14,6 @@ test -d "${KW_INSTALL_DIR}"  && rm -rv "${KW_INSTALL_DIR}"
 ./configure.py --makefile $PWD/sites/gce/Makefile.site.gnu_mpich --dim 2 --runtime HOSTMEM --offload OpenACC --prefix ${KW_INSTALL_DIR} \
 	       --support_exec --support_push --support_packets
 make clean
-# The following is required on gce for building sizes.json, only needed for --support_packets
-export MILHOJA_TEST_CLONE=/nfs/gce/projects/Milhoja/MilhojaTest
+# export MILHOJA_TEST_CLONE=/nfs/gce/projects/Milhoja/MilhojaTest
 make -j12 all
 make install

--- a/sites/gce/kw_build_inst.sh
+++ b/sites/gce/kw_build_inst.sh
@@ -6,7 +6,7 @@ export MILHOJA_CODE_REPO=/home/kweide/projects/Milhoja
 export KW_INSTALL_DIR=/nfs/gce/projects/FLASH5/kweide/local-milhoja/2d
 
 set -xve
-cd ${MILHOJA_CODE_REPO} # top of cloned OrchestrationRuntime repo
+cd ${MILHOJA_CODE_REPO} # top of cloned Milhoja repo
 
 test -f Makefile.configure   && rm -v  Makefile.configure
 test -d build/               && rm -rv build/
@@ -14,6 +14,5 @@ test -d "${KW_INSTALL_DIR}"  && rm -rv "${KW_INSTALL_DIR}"
 ./configure.py --makefile $PWD/sites/gce/Makefile.site.gnu_mpich --dim 2 --runtime HOSTMEM --offload OpenACC --prefix ${KW_INSTALL_DIR} \
 	       --support_exec --support_push --support_packets
 make clean
-# export MILHOJA_TEST_CLONE=/nfs/gce/projects/Milhoja/MilhojaTest
 make -j12 all
 make install

--- a/sites/summit/Makefile.site.nvhpc
+++ b/sites/summit/Makefile.site.nvhpc
@@ -7,7 +7,6 @@
 BASEDIR      = $(MILHOJA_CODE_REPO)
 AMREXDIR     = $(MILHOJA_TEST_CLONE)/summit/nvhpc_current/AMReX_$(NDIM)d
 GTESTDIR     = $(MILHOJA_TEST_CLONE)/summit/nvhpc_current/googletest
-JSONDIR      = $(OLCF_NLOHMANN_JSON_ROOT)/include
 CUDADIR      = $(OLCF_CUDA_ROOT)
 
 # Define the following compiler-related flags

--- a/sites/swing/Makefile.site.nvhpc
+++ b/sites/swing/Makefile.site.nvhpc
@@ -14,7 +14,6 @@
 BASEDIR      = 
 AMREXDIR     = $(FLASHX_AMREX$(NDIM)D_DIR)
 GTESTDIR     = $(FLASHX_GTEST_DIR)
-JSONDIR      = /lcrc/project/Flash-X/soft/src/json/include
 CUDADIR      = $(NVHPC_CUDA_HOME)
 
 # Define the following compiler-related flags

--- a/src/CudaBackend/Milhoja_CudaGpuEnvironment.cu
+++ b/src/CudaBackend/Milhoja_CudaGpuEnvironment.cu
@@ -14,7 +14,6 @@ bool    CudaGpuEnvironment::finalized_   = false;
 /**
  * 
  *
- * \return 
  */
 void   CudaGpuEnvironment::initialize(void) {
     // finalized_ => initialized_
@@ -73,7 +72,6 @@ CudaGpuEnvironment& CudaGpuEnvironment::instance(void) {
 /**
  * 
  *
- * \return 
  */
 CudaGpuEnvironment::CudaGpuEnvironment(void)
     : nDevices_{0},

--- a/src/CudaBackend/Milhoja_CudaMemoryManager.cu
+++ b/src/CudaBackend/Milhoja_CudaMemoryManager.cu
@@ -14,7 +14,6 @@ bool          CudaMemoryManager::finalized_ = false;
 
 /**
  *
- * \return 
  */
 void CudaMemoryManager::initialize(const std::size_t nBytesInMemoryPools) {
     // finalized_ => initialized_
@@ -111,7 +110,6 @@ CudaMemoryManager&   CudaMemoryManager::instance(void) {
 /**
  * 
  *
- * \return 
  */
 CudaMemoryManager::CudaMemoryManager(void)
     : pinnedBuffer_{nullptr},
@@ -166,7 +164,6 @@ CudaMemoryManager::CudaMemoryManager(void)
 /**
  * 
  *
- * \return 
  */
 CudaMemoryManager::~CudaMemoryManager(void) {
     if (initialized_ && !finalized_) {
@@ -178,7 +175,6 @@ CudaMemoryManager::~CudaMemoryManager(void) {
 /**
  * 
  *
- * \return 
  */
 void   CudaMemoryManager::reset(void) {
     // There is no mechanism for now for releasing memory on a per request

--- a/src/CudaBackend/Milhoja_CudaStreamManager.cu
+++ b/src/CudaBackend/Milhoja_CudaStreamManager.cu
@@ -117,7 +117,6 @@ CudaStreamManager&   CudaStreamManager::instance(void) {
 /**
  * 
  *
- * \return 
  */
 CudaStreamManager::CudaStreamManager(void)
     : streams_{}

--- a/src/FakeCudaBackend/Milhoja_FakeCudaGpuEnvironment.cpp
+++ b/src/FakeCudaBackend/Milhoja_FakeCudaGpuEnvironment.cpp
@@ -15,7 +15,6 @@ bool    FakeCudaGpuEnvironment::finalized_   = false;
 /**
  * 
  *
- * \return 
  */
 void   FakeCudaGpuEnvironment::initialize(void) {
     // finalized_ => initialized_
@@ -74,7 +73,6 @@ FakeCudaGpuEnvironment& FakeCudaGpuEnvironment::instance(void) {
 /**
  * 
  *
- * \return 
  */
 FakeCudaGpuEnvironment::FakeCudaGpuEnvironment(void)
     : nDevices_{0},

--- a/src/FakeCudaBackend/Milhoja_FakeCudaMemoryManager.cpp
+++ b/src/FakeCudaBackend/Milhoja_FakeCudaMemoryManager.cpp
@@ -15,7 +15,6 @@ bool          FakeCudaMemoryManager::finalized_ = false;
 
 /**
  *
- * \return 
  */
 void FakeCudaMemoryManager::initialize(const std::size_t nBytesInMemoryPools) {
     // finalized_ => initialized_
@@ -114,7 +113,6 @@ FakeCudaMemoryManager&   FakeCudaMemoryManager::instance(void) {
 /**
  * 
  *
- * \return 
  */
 FakeCudaMemoryManager::FakeCudaMemoryManager(void)
     : pinnedBuffer_{nullptr},
@@ -163,7 +161,6 @@ FakeCudaMemoryManager::FakeCudaMemoryManager(void)
 /**
  * 
  *
- * \return 
  */
 FakeCudaMemoryManager::~FakeCudaMemoryManager(void) {
     if (initialized_ && !finalized_) {
@@ -175,7 +172,6 @@ FakeCudaMemoryManager::~FakeCudaMemoryManager(void) {
 /**
  * 
  *
- * \return 
  */
 void   FakeCudaMemoryManager::reset(void) {
     // There is no mechanism for now for releasing memory on a per request

--- a/src/FakeCudaBackend/Milhoja_FakeCudaStreamManager.cpp
+++ b/src/FakeCudaBackend/Milhoja_FakeCudaStreamManager.cpp
@@ -118,7 +118,6 @@ FakeCudaStreamManager&   FakeCudaStreamManager::instance(void) {
 /**
  * 
  *
- * \return 
  */
 FakeCudaStreamManager::FakeCudaStreamManager(void)
     : streams_{}

--- a/src/Milhoja_CpuMemoryManager.cpp
+++ b/src/Milhoja_CpuMemoryManager.cpp
@@ -18,7 +18,6 @@ bool          CpuMemoryManager::finalized_ = false;
  *
  * \todo Check that memory pools are sized for byte alignment?
  *
- * \return 
  */
 void CpuMemoryManager::initialize(const std::size_t nBytesInMemoryPool) {
     // finalized_ => initialized_

--- a/src/Milhoja_Runtime.cpp
+++ b/src/Milhoja_Runtime.cpp
@@ -34,7 +34,6 @@ bool            Runtime::finalized_         = false;
 /**
  * 
  *
- * \return 
  */
 void   Runtime::initialize(const unsigned int nTeams,
                             const unsigned int nThreadsPerTeam,
@@ -121,7 +120,6 @@ Runtime& Runtime::instance(void) {
 /**
  * 
  *
- * \return 
  */
 Runtime::Runtime(void)
     : teams_{nullptr}
@@ -147,7 +145,6 @@ Runtime::Runtime(void)
 /**
  * 
  *
- * \return 
  */
 #ifndef RUNTIME_MUST_USE_TILEITER
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/src/Milhoja_ThreadTeam.cpp
+++ b/src/Milhoja_ThreadTeam.cpp
@@ -446,7 +446,6 @@ ThreadTeamMode ThreadTeam::mode(void) {
 /**
  * Obtain the current mode of the team.
  *
- * \return The mode as an enum
  */
 void ThreadTeam::stateCounts(unsigned int* N_idle,
                                  unsigned int* N_wait,

--- a/tools/createSizesJson.cpp
+++ b/tools/createSizesJson.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <fstream>
 #include <tuple>
-#include <nlohmann/json.hpp>
 
 #include <Milhoja.h>
 #include <Milhoja_real.h>
@@ -45,26 +44,26 @@ int main(int argc, char* argv[]) {
 //        FArray3D, FArray4D, std::size_t
 //    >;
     //----- CREATE NEW JSON OBJECT
-    nlohmann::json sizes = {
-        {"byte_align", BYTE_ALIGNMENT},
-        {"int", sizeof(int)},
-        {"unsigned int", sizeof(unsigned int)},
-        {"std::size_t", sizeof(std::size_t)},
-        {"real", sizeof(milhoja::Real)},
-        {"IntVect", sizeof(milhoja::IntVect)},
-        {"RealVect", sizeof(milhoja::RealVect)},
-        {"FArray1D", sizeof(milhoja::FArray1D)},
-        {"FArray2D", sizeof(milhoja::FArray2D)},
-        {"FArray3D", sizeof(milhoja::FArray3D)},
-        {"FArray4D", sizeof(milhoja::FArray4D)}
-    };
+//    nlohmann::json sizes = {
+//        {"byte_align", BYTE_ALIGNMENT},
+//        {"int", sizeof(int)},
+//        {"unsigned int", sizeof(unsigned int)},
+//        {"std::size_t", sizeof(std::size_t)},
+//        {"real", sizeof(milhoja::Real)},
+//        {"IntVect", sizeof(milhoja::IntVect)},
+//        {"RealVect", sizeof(milhoja::RealVect)},
+//        {"FArray1D", sizeof(milhoja::FArray1D)},
+//        {"FArray2D", sizeof(milhoja::FArray2D)},
+//        {"FArray3D", sizeof(milhoja::FArray3D)},
+//        {"FArray4D", sizeof(milhoja::FArray4D)}
+//    };
 
     //----- SAVE TO FILE
     std::ofstream output;
     output.exceptions(std::ofstream::failbit | std::ofstream::badbit);
     try {
         output.open(filename, std::ofstream::out | std::ofstream::trunc);
-        //output << "{" << std::endl;
+        output << "{" << std::endl;
 
         // TODO: There should be a better way to print the name of a data
         //       type and its size by using a std::tuple object as well as
@@ -74,20 +73,20 @@ int main(int argc, char* argv[]) {
         //       variable for using a specific json library. However, for the
         //       sake of getting the datapacket_tests into main, I'll ignore
         //       this for now.
-        //output << "    \"byte_align\": " << BYTE_ALIGNMENT << "," << std::endl;
-        //output << "    \"int\": " << sizeof(int) << "," << std::endl;
-        //output << "    \"unsigned int\": " << sizeof(unsigned int) << "," << std::endl;
-        //output << "    \"std::size_t\": " << sizeof(std::size_t) << "," << std::endl;
-        //output << "    \"real\": " << sizeof(milhoja::Real) << "," << std::endl;
-        //output << "    \"IntVect\": " << sizeof(milhoja::IntVect) << "," << std::endl;
-        //output << "    \"RealVect\": " << sizeof(milhoja::RealVect) << "," << std::endl;
-        //output << "    \"FArray1D\": " << sizeof(milhoja::FArray1D) << "," << std::endl;
-        //output << "    \"FArray2D\": " << sizeof(milhoja::FArray2D) << "," << std::endl;
-        //output << "    \"FArray3D\": " << sizeof(milhoja::FArray3D) << "," << std::endl;
-        //output << "    \"FArray4D\": " << sizeof(milhoja::FArray4D) << std::endl;
-        output << sizes.dump(INDENT);
+        output << "    \"byte_align\": " << BYTE_ALIGNMENT << "," << std::endl;
+        output << "    \"int\": " << sizeof(int) << "," << std::endl;
+        output << "    \"unsigned int\": " << sizeof(unsigned int) << "," << std::endl;
+        output << "    \"std::size_t\": " << sizeof(std::size_t) << "," << std::endl;
+        output << "    \"real\": " << sizeof(milhoja::Real) << "," << std::endl;
+        output << "    \"IntVect\": " << sizeof(milhoja::IntVect) << "," << std::endl;
+        output << "    \"RealVect\": " << sizeof(milhoja::RealVect) << "," << std::endl;
+        output << "    \"FArray1D\": " << sizeof(milhoja::FArray1D) << "," << std::endl;
+        output << "    \"FArray2D\": " << sizeof(milhoja::FArray2D) << "," << std::endl;
+        output << "    \"FArray3D\": " << sizeof(milhoja::FArray3D) << "," << std::endl;
+        output << "    \"FArray4D\": " << sizeof(milhoja::FArray4D) << std::endl;
+        //output << sizes.dump(INDENT);
         
-        //output << "}" << std::endl;
+        output << "}" << std::endl;
         output.close();
     } catch (std::ifstream::failure e) {
         std::cerr << "Unable to open, write to, or close " << filename << std::endl;


### PR DESCRIPTION
Build json.sizes without json.hpp.

With this patch, a header file `json.hpp` is neither included in the set of source files, nor needed in the form of a reference to a separate repository. The file `json.sizes` (usually needed for installations of the Milhoja library to work) can be created (by a modified version of `tools/createSizesJson.cpp`) just fine without a `json.hpp`. 